### PR TITLE
Allow to parse just a lang sub-directory instead of all lang directory

### DIFF
--- a/config/i18n.php
+++ b/config/i18n.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Sub directory
+    |--------------------------------------------------------------------------
+    |
+    | Parse files just from a specific sub-directory instead of all files in /lang/{lang}
+    | Leave it as null/false/empty string to parse every files inside /lang directory.
+    | When specified, it must start with a directory separator.
+    |
+    | For example: '/js'
+    |
+    */
+
+    'initial_dir' => '/js',
+
+];

--- a/src/I18nServiceProvider.php
+++ b/src/I18nServiceProvider.php
@@ -17,6 +17,7 @@ class I18nServiceProvider extends ServiceProvider
     {
         // Publish the assets
         $this->publishes([
+            __DIR__.'/../config/i18n.php' => config_path('i18n.php'),
             __DIR__.'/../resources/js' => resource_path(
                 version_compare($this->app->version(), '5.7.0', '<')
                 ? 'assets/js/vendor' : 'js/vendor'
@@ -48,9 +49,11 @@ class I18nServiceProvider extends ServiceProvider
      */
     protected function translations()
     {
-        $translations = collect(File::directories(resource_path('lang')))->mapWithKeys(function ($dir) {
+        $startDir = config('i18n.initial_dir');
+
+        $translations = collect(File::directories(resource_path('lang')))->mapWithKeys(function ($dir) use ($startDir) {
             return [
-                basename($dir) => collect($this->getFiles($dir))->flatMap(function ($file) {
+                basename($dir) => collect($this->getFiles($dir . $startDir))->flatMap(function ($file) {
                     return [
                         $file->getBasename('.php') => (include $file->getPathname()),
                     ];


### PR DESCRIPTION
Allow to specify a sub directory to parse, instead of parse everything inside the lang folder.

For example, if you have a `js` directory under `lang` directory, maybe you just want to parse what is under this directory instead of all `lang` directory.